### PR TITLE
Display blog post tags

### DIFF
--- a/content/blog/build-your-php-docker-artifact/index.md
+++ b/content/blog/build-your-php-docker-artifact/index.md
@@ -3,6 +3,7 @@ title: Build your PHP/Nginx docker artifact
 date: "2018-07-16T15:34:04.169Z"
 description: "And not one more."
 published: true
+tags: ["container", "best practice"]
 ---
 
 I have always been bothered by a simple issue when building docker image artifacts for my PHP/Nginx applications. The issue of building **two docker image artifacts** instead of **just one** with my PHP source code.

--- a/content/blog/my-non-technical-colleague-outdid-my-2-year-work-in-1-month/index.md
+++ b/content/blog/my-non-technical-colleague-outdid-my-2-year-work-in-1-month/index.md
@@ -3,6 +3,7 @@ title: My non-technical colleague outdid my 2-year work in 1 month
 date: "2018-08-11T11:23:22.169Z"
 description: "Through this story, I want to highlight a fact I learnt the hard way: we, developers, need to seek for simplicity, at its essence."
 published: true
+tags: ["mvp", "learnings"]
 ---
 
 Through this story, I want to highlight a fact I learnt the hard way: we, developers, need to seek for simplicity, at its essence.

--- a/content/blog/replay-a-jenkins-build-pipeline-locally/index.md
+++ b/content/blog/replay-a-jenkins-build-pipeline-locally/index.md
@@ -3,6 +3,7 @@ title: Replay a Jenkins build pipeline locally
 date: "2017-01-24T12:10:54.169Z"
 description: "Let me introduce you, in a nutshell, a way to iterate on a Jenkins pipeline on your local machine."
 published: true
+tags: ["jenkins"]
 ---
 
 Let me introduce you, in a nutshell, a way to iterate on a Jenkins pipeline on your local machine.

--- a/content/blog/traefik-as-an-ingress-controller-on-minikube-with-kustomize-helm/index.md
+++ b/content/blog/traefik-as-an-ingress-controller-on-minikube-with-kustomize-helm/index.md
@@ -3,6 +3,7 @@ title: Traefik as an ingress controller on minikube with kustomize & helm
 date: "2019-07-17T07:31:00.169Z"
 description: "I wanted to mess around with skaffold and do it with a clean minikube setup. And by clean I mean one where I can access my services locally via a nice hostname like myservice.dev. I am quite…"
 published: true
+tags: ["kubernetes"]
 ---
 
 I wanted to mess around with [skaffold](https://skaffold.dev/) and do it with a clean minikube setup. And by clean I mean one where I can access my services locally via a nice hostname like myservice.dev.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -42,7 +42,12 @@ const BlogIndex = ({ data, location }) => {
                       <span itemProp="headline">{title}</span>
                     </Link>
                   </h2>
-                  <small>{post.frontmatter.date}</small>
+                  <small>
+                    <span>{post.frontmatter.date}</span>
+                    {post.frontmatter.tags?.map(tag => (
+                      <span className='tag'>#{tag}</span>
+                    ))}
+                  </small>
                 </header>
                 <section>
                   <p
@@ -96,6 +101,7 @@ export const pageQuery = graphql`
           date(formatString: "MMMM DD, YYYY")
           title
           description
+          tags
         }
       }
     }

--- a/src/styles/fonts/jetbrains-mono.css
+++ b/src/styles/fonts/jetbrains-mono.css
@@ -1,9 +1,7 @@
 @font-face {
     font-family: 'JetBrains Mono';
-    src: url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/eot/JetBrainsMono-Regular.eot') format('embedded-opentype'),
-        url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/woff2/JetBrainsMono-Regular.woff2') format('woff2'),
-        url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/web/woff/JetBrainsMono-Regular.woff') format('woff'),
-        url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/master/ttf/JetBrainsMono-Regular.ttf') format('truetype');
+    src: url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/v2.304/fonts/webfonts/JetBrainsMono-Regular.woff2') format('woff2'),
+         url('https://raw.githubusercontent.com/JetBrains/JetBrainsMono/v2.304/fonts/ttf/JetBrainsMono-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }

--- a/src/styles/gatsby-starter-blog/base.css
+++ b/src/styles/gatsby-starter-blog/base.css
@@ -52,6 +52,7 @@
   --color-primary: #247cb7;
   --color-text: #181818;
   --color-text-light: #4f5969;
+  --color-text-extra-light: #9098a5;
   --color-heading: #1a202c;
   --color-heading-black: black;
   --color-accent: #d1dce5;
@@ -303,6 +304,11 @@ a:focus {
   font-size: var(--fontSize-0);
   font-family: var(--font-heading);
   color: var(--color-text-light);
+}
+
+.post-list-item header span.tag, .blog-post header p span.tag {
+  padding-left: 10px;
+  color: var(--color-text-extra-light);
 }
 
 .blog-post-nav ul {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -20,7 +20,12 @@ const BlogPostTemplate = ({
       >
         <header>
           <h1 itemProp="headline">{post.frontmatter.title}</h1>
-          <p>{post.frontmatter.date}</p>
+          <p>
+            <span>{post.frontmatter.date}</span>
+            {post.frontmatter.tags?.map(tag => (
+              <span className='tag'>#{tag}</span>
+            ))}
+          </p>
         </header>
         <section
           dangerouslySetInnerHTML={{ __html: post.html }}
@@ -95,6 +100,7 @@ export const pageQuery = graphql`
         title
         date(formatString: "MMMM DD, YYYY")
         description
+        tags
       }
     }
     previous: markdownRemark(id: { eq: $previousPostId }) {


### PR DESCRIPTION
## Description

Ici, on ajoute la notion de tags au sein d'un article.

Le but est de les afficher uniquement, on créera des pages thématique plus tard [[ref](https://www.gatsbyjs.com/docs/adding-tags-and-categories-to-blog-posts/)].

## Todo

- [x] ajouter des tags à chaque article
- [x] afficher les tags dans la liste des articles
- [x] afficher les tags dans les pages de post