### PR TITLE
Fix ordered list styling

### DIFF
--- a/src/styles/gatsby-starter-blog/base.css
+++ b/src/styles/gatsby-starter-blog/base.css
@@ -184,7 +184,7 @@ li *:last-child {
   margin-bottom: var(--spacing-0);
 }
 
-ul > li {
+ul > li, ol > li {
   margin-left: var(--spacing-8);
   margin-top: calc(var(--spacing-8) / 2);
 }


### PR DESCRIPTION
## Description

Ordered list items were outside of the body, this PR pushes them to the right using the same left margin as unordered list items.

## Screenshots

Before:

![Screenshot_20240501_110806](https://github.com/fhuitelec/blog/assets/6122860/4d1e8e5e-d649-4eb7-b5b4-611d8af1bba9)

After:

![Screenshot_20240501_110754](https://github.com/fhuitelec/blog/assets/6122860/26981d22-2f1d-4899-9462-680d97efd7d2)