### PR TITLE
Tiny style fixes

### DIFF
--- a/src/styles/code-highlight-darcula.css
+++ b/src/styles/code-highlight-darcula.css
@@ -82,6 +82,10 @@ pre[class*="language-"] {
     color: #a9b7c6;
 }
 
+.token.operator {
+    background: none;
+}
+
 .token.tag,
 .token.tag .punctuation,
 .token.doctype,

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -104,7 +104,7 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
-        date(formatString: "YYYY, DD MMMM", locale: "fr")
+        date(formatString: "Do MMMM YYYY", locale: "fr")
         description
         tags
         language


### PR DESCRIPTION
## Description

In this PR, we are fixing 2 issues:
- the `=` operator in syntax highlight code blocks has an ugly background
- the day token is not correctly formatted within the date ("1 mai" instead of "1er mai")

> [!Note]
> We used [moment.js API reference](https://momentjs.com/docs/#/parsing/string-format/) for formatting